### PR TITLE
Update wit-bindgen-cli installation instructions

### DIFF
--- a/components/moonbit/http-hello-world/README.md
+++ b/components/moonbit/http-hello-world/README.md
@@ -9,8 +9,8 @@ This example was created following the [Developing Wasm component model in MoonB
   - `cargo install wit-deps-cli`
 - wasm-tools
   - `cargo install wasm-tools`
-- Moonbit wit-bindgen fork
-  - `cargo install wit-bindgen-cli --git https://github.com/peter-jerry-ye/wit-bindgen/ --branch moonbit`
+- wit-bindgen
+  - `cargo install wit-bindgen-cli`
 - [Moonbit CLI](https://www.moonbitlang.com/download/#moonbit-cli-tools)
 - [wash CLI](https://wasmcloud.com/docs/installation)
 


### PR DESCRIPTION
I've updated the installation instructions for wit-bindgen-cli.
Previously, the documentation mentioned installing a forked version of wit-bindgen-cli from a specific Git repository and branch to get Moonbit support.
However, Moonbit support is now officially included in the main wit-bindgen-cli package. This means we no longer need to use a special fork. Users can now install it directly without any extra steps.
This change simplifies the installation process and ensures users are getting the official, up-to-date version.